### PR TITLE
Add support for more actions

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -258,7 +258,13 @@ class SchwabJsonParser(AbstractStatementParser):
             amount=withdrawal or deposit,
         )
         line.check_no = details.get("CheckNumber")
-        line.trntype = POSTED_TRANSACTION_TYPES[details["Type"]]
+        if details["Type"] == "ACH":
+            if withdrawal:
+                line.trntype = "DEBIT"
+            else:
+                line.trntype = "CREDIT"
+        else:
+            line.trntype = POSTED_TRANSACTION_TYPES[details["Type"]]
 
         line.assert_valid()
         self.statement.lines.append(line)

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -74,6 +74,8 @@ class SchwabJsonParser(AbstractStatementParser):
                 self.add_buy_line(id, date, tran)
             elif action == "ADR Mgmt Fee":
                 self.add_bank_line(id, date, "SRVCHG", tran)
+            elif action == "Advisor Fee":
+                self.add_bank_line(id, date, "XFER", tran)
             elif len(tran["Symbol"]) > 0 and (
                 action == "Journaled Shares"
                 or action == "Spin-off"

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -84,6 +84,10 @@ class SchwabJsonParser(AbstractStatementParser):
                 or action == "Security Transfer"
             ):
                 self.add_transfer_line(id, date, tran)
+            elif len(tran["Symbol"]) > 0 and (
+                action == "Journal"
+            ):
+                self.add_transfer_line(id, date, tran)
             elif len(tran["Symbol"]) == 0:
                 if (
                     action == "Bank Interest"

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -78,14 +78,11 @@ class SchwabJsonParser(AbstractStatementParser):
             elif action == "Advisor Fee":
                 self.add_bank_line(id, date, "XFER", tran)
             elif len(tran["Symbol"]) > 0 and (
-                action == "Journaled Shares"
+                action == "Journal"
+                or action == "Journaled Shares"
                 or action == "Spin-off"
                 or action == "Stock Split"
                 or action == "Security Transfer"
-            ):
-                self.add_transfer_line(id, date, tran)
-            elif len(tran["Symbol"]) > 0 and (
-                action == "Journal"
             ):
                 self.add_transfer_line(id, date, tran)
             elif len(tran["Symbol"]) == 0:

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -17,6 +17,7 @@ import json
 POSTED_TRANSACTION_TYPES = {
     # Map Schwab PostedTransactions types to ofxstatement TRANSACTION_TYPES
     "ATM": "ATM",
+    "DEBIT": "DEBIT",
     "INTADJUST": "INT",
     "TRANSFER": "XFER",
 }

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -97,10 +97,8 @@ class SchwabJsonParser(AbstractStatementParser):
                 self.add_invexpense_line(id, date, tran)
             elif action == "Buy" or action == "Reinvest Shares":
                 self.add_buy_line(id, date, tran)
-            elif action == "ADR Mgmt Fee":
+            elif action == "ADR Mgmt Fee" or action == "Advisor Fee":
                 self.add_bank_line(id, date, "SRVCHG", tran)
-            elif action == "Advisor Fee":
-                self.add_bank_line(id, date, "XFER", tran)
             elif len(tran["Symbol"]) > 0 and (
                 action == "Journal"
                 or action == "Journaled Shares"

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -59,6 +59,7 @@ class SchwabJsonParser(AbstractStatementParser):
                 or action == "Pr Yr Non-Qual Div"
                 or action == "Qual Div Reinvest"
                 or action == "Reinvest Dividend"
+                or action == "Special Dividend"
                 or action == "Div Adjustment"
             ):
                 self.add_income_line(id, date, "DIV", tran)

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -93,6 +93,7 @@ class SchwabJsonParser(AbstractStatementParser):
                     self.add_bank_line(id, date, "INT", tran)
                 elif (
                     action == "MoneyLink Transfer"
+                    or action == "Bank Transfer"
                     or action == "Internal Transfer"
                     or action == "Journal"
                     or action == "Journaled Shares"

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,16 @@
   "TotalTransactionsAmount": "$526.12",
   "BrokerageTransactions": [
     {
+      "Date": "03/21/2025",
+      "Action": "Special Dividend",
+      "Symbol": "MTUM",
+      "Description": "ISHARES MSCI USA MOMNTUMFCT ETF",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$19.59"
+    },
+    {
       "Date": "06/10/2025",
       "Action": "Advisor Fee",
       "Symbol": "",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "ZELLE TO JOHN DOE",
+      "Date": "06/15/2025",
+      "RunningBalance": "$700.00",
+      "Withdrawal": "$100.00",
+      "Deposit": "",
+      "Type": "DEBIT"
+    },
+    {
+      "CheckNumber": null,
       "Description": "CHASE MAIN ST ANYTOWN",
       "Date": "06/07/2025",
       "RunningBalance": "$929.53",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,26 @@
   "TotalTransactionsAmount": "$526.12",
   "BrokerageTransactions": [
     {
+      "Date": "06/02/2025",
+      "Action": "Journal",
+      "Symbol": "SNSXX",
+      "Description": "SCHWAB US TREASURY MONEY INVESTOR",
+      "Quantity": "103.26",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": ""
+    },
+    {
+      "Date": "06/02/2025",
+      "Action": "Journal",
+      "Symbol": "SNSXX",
+      "Description": "SCHWAB US TREASURY MONEY INVESTOR",
+      "Quantity": "-103.26",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": ""
+    },
+    {
       "Date": "05/29/2025",
       "Action": "Bank Transfer",
       "Symbol": "",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,16 @@
   "TotalTransactionsAmount": "$526.12",
   "BrokerageTransactions": [
     {
+      "Date": "06/10/2025",
+      "Action": "Advisor Fee",
+      "Symbol": "",
+      "Description": "MGMTFEE TO ADVISOR",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "-$419.08"
+    },
+    {
       "Date": "05/15/2025",
       "Action": "NRA Tax Adj",
       "Symbol": "AAPL",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,24 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "TRIAL ACCTVERIFY 250615",
+      "Date": "06/16/2025",
+      "RunningBalance": "$549.87",
+      "Withdrawal": "$0.46",
+      "Deposit": "",
+      "Type": "ACH"
+    },
+    {
+      "CheckNumber": null,
+      "Description": "TRIAL ACCTVERIFY 250615",
+      "Date": "06/16/2025",
+      "RunningBalance": "$550.33",
+      "Withdrawal": "",
+      "Deposit": "$0.25",
+      "Type": "ACH"
+    },
+    {
+      "CheckNumber": null,
       "Description": "ZELLE TO JOHN DOE",
       "Date": "06/15/2025",
       "RunningBalance": "$700.00",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,16 @@
   "TotalTransactionsAmount": "$526.12",
   "BrokerageTransactions": [
     {
+      "Date": "05/29/2025",
+      "Action": "Bank Transfer",
+      "Symbol": "",
+      "Description": "JOURNAL FUNDS TO INVESTOR CHECKING",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "-$100.00"
+    },
+    {
       "Date": "03/21/2025",
       "Action": "Special Dividend",
       "Symbol": "MTUM",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.invest_lines) == 24
+    assert len(statement.invest_lines) == 25
 
 
 def test_ids(statement):
@@ -237,4 +237,14 @@ def test_nra_tax_adj(statement):
     assert line.units is None
     assert line.amount == Decimal("-0.29")
     assert line.security_id == "AAPL"
+    assert line.unit_price is None
+
+
+def test_advisor_fee(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20250610-1")
+    assert line.trntype == "INVBANKTRAN"
+    assert line.trntype_detailed == "XFER"
+    assert line.units is None
+    assert line.amount == Decimal("-419.08")
+    assert line.security_id is None
     assert line.unit_price is None

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.invest_lines) == 27
+    assert len(statement.invest_lines) == 29
 
 
 def test_ids(statement):
@@ -79,6 +79,26 @@ def test_journal_security(statement):
     assert line.security_id == "SWVXX"
     assert line.unit_price == 1
     assert line.amount == 0
+
+
+def test_journal_security2(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20250602-1")
+    assert line.trntype == "TRANSFER"
+    assert line.trntype_detailed is None
+    assert line.units == Decimal("-103.26")
+    assert line.security_id == "SNSXX"
+    assert line.unit_price == Decimal("0")
+    assert line.amount == Decimal("0")
+
+
+def test_journal_security3(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20250602-2")
+    assert line.trntype == "TRANSFER"
+    assert line.trntype_detailed is None
+    assert line.units == Decimal("103.26")
+    assert line.security_id == "SNSXX"
+    assert line.unit_price == Decimal("0")
+    assert line.amount == Decimal("0")
 
 
 def test_security_transfer(statement):

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -286,7 +286,7 @@ def test_nra_tax_adj(statement):
 def test_advisor_fee(statement):
     line = next(x for x in statement.invest_lines if x.id == "20250610-1")
     assert line.trntype == "INVBANKTRAN"
-    assert line.trntype_detailed == "XFER"
+    assert line.trntype_detailed == "SRVCHG"
     assert line.units is None
     assert line.amount == Decimal("-419.08")
     assert line.security_id is None

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.invest_lines) == 25
+    assert len(statement.invest_lines) == 26
 
 
 def test_ids(statement):
@@ -138,6 +138,16 @@ def test_dividend4(statement):
     assert line.units is None
     assert line.amount == Decimal("622.50")
     assert line.security_id == "HASI"
+    assert line.unit_price is None
+
+
+def test_dividend5_special_dividend(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20250321-1")
+    assert line.trntype == "INCOME"
+    assert line.trntype_detailed == "DIV"
+    assert line.units is None
+    assert line.amount == Decimal("19.59")
+    assert line.security_id == "MTUM"
     assert line.unit_price is None
 
 

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 4
+    assert len(statement.lines) == 6
     assert len(statement.invest_lines) == 29
 
 
@@ -319,3 +319,17 @@ def test_posted_debit(statement):
     assert line.memo == "ZELLE TO JOHN DOE"
     assert line.trntype == "DEBIT"
     assert line.amount == Decimal("-100")
+
+
+def test_posted_ach_deposit(statement):
+    line = next(x for x in statement.lines if x.id == "20250616-1")
+    assert line.memo == "TRIAL ACCTVERIFY 250615"
+    assert line.trntype == "CREDIT"
+    assert line.amount == Decimal("0.25")
+
+
+def test_posted_ach_withdrawal(statement):
+    line = next(x for x in statement.lines if x.id == "20250616-2")
+    assert line.memo == "TRIAL ACCTVERIFY 250615"
+    assert line.trntype == "DEBIT"
+    assert line.amount == Decimal("-0.46")

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 3
+    assert len(statement.lines) == 4
     assert len(statement.invest_lines) == 29
 
 
@@ -312,3 +312,10 @@ def test_posted_transfer(statement):
     assert line.memo == "Funds Transfer from Brokerage"
     assert line.trntype == "XFER"
     assert line.amount == Decimal("100")
+
+
+def test_posted_debit(statement):
+    line = next(x for x in statement.lines if x.id == "20250615-1")
+    assert line.memo == "ZELLE TO JOHN DOE"
+    assert line.trntype == "DEBIT"
+    assert line.amount == Decimal("-100")

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.invest_lines) == 26
+    assert len(statement.invest_lines) == 27
 
 
 def test_ids(statement):
@@ -36,6 +36,16 @@ def test_transfer_cash(statement):
     assert line.trntype == "INVBANKTRAN"
     assert line.trntype_detailed == "XFER"
     assert line.amount == -1500
+    assert line.security_id is None
+    assert line.units is None
+    assert line.unit_price is None
+
+
+def test_transfer_cash_bank(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20250529-1")
+    assert line.trntype == "INVBANKTRAN"
+    assert line.trntype_detailed == "XFER"
+    assert line.amount == -100
     assert line.security_id is None
     assert line.units is None
     assert line.unit_price is None


### PR DESCRIPTION
More posted transaction support (checking account):
- "DEBIT"
- "ACH" credit and debit

More brokerage transaction actions:
- "Journal" with Symbol
- "Bank Transfer"
- "Special Dividend"
- "Advisor Fee"