### PR TITLE
Sort transactions by date and tie-breaker fields

### DIFF
--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -85,8 +85,8 @@ def test_buy(statement):
     line = next(x for x in statement.invest_lines if x.id == "20230922-1")
     assert line.trntype == "BUYSTOCK"
     assert line.trntype_detailed == "BUY"
-    assert line.units == 100
-    assert line.amount == -100
+    assert line.units == 500
+    assert line.amount == -500
     assert line.security_id == "SWVXX"
     assert line.unit_price == 1
 
@@ -162,7 +162,7 @@ def test_wire(statement):
 
 
 def test_bank_fee(statement):
-    line = next(x for x in statement.invest_lines if x.id == "20231212-1")
+    line = next(x for x in statement.invest_lines if x.id == "20231212-2")
     assert line.trntype == "INVBANKTRAN"
     assert line.trntype_detailed == "SRVCHG"
     assert line.amount == Decimal("-15")
@@ -172,7 +172,7 @@ def test_bank_fee(statement):
 
 
 def test_bank_misc(statement):
-    line = next(x for x in statement.invest_lines if x.id == "20231212-2")
+    line = next(x for x in statement.invest_lines if x.id == "20231212-1")
     assert line.trntype == "INVBANKTRAN"
     assert line.trntype_detailed == "OTHER"
     assert line.amount == Decimal("15")


### PR DESCRIPTION
Sort statements by date and a few tie-breaker fields, rather than simply depending on the transaction order in the input file.

The unit tests assume the input file is already sorted by reverse date. Add explicit sorting to the file-reading code to make the unit tests more robust.