### PR TITLE
PostedTransactions: add support for Checking accounts

### DIFF
--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -2,6 +2,35 @@
   "FromDate": "12/20/2023",
   "ToDate": "02/11/2024",
   "TotalTransactionsAmount": "$526.12",
+  "PostedTransactions": [
+    {
+      "CheckNumber": null,
+      "Description": "CHASE MAIN ST ANYTOWN",
+      "Date": "06/07/2025",
+      "RunningBalance": "$929.53",
+      "Withdrawal": "$23.50",
+      "Deposit": "",
+      "Type": "ATM"
+    },
+    {
+      "CheckNumber": null,
+      "Description": "Interest Paid",
+      "Date": "05/30/2025",
+      "RunningBalance": "$100.03",
+      "Withdrawal": "",
+      "Deposit": "$0.03",
+      "Type": "INTADJUST"
+    },
+    {
+      "CheckNumber": null,
+      "Description": "Funds Transfer from Brokerage",
+      "Date": "05/29/2025",
+      "RunningBalance": "$100.00",
+      "Withdrawal": "",
+      "Deposit": "$100.00",
+      "Type": "TRANSFER"
+    }
+  ],
   "BrokerageTransactions": [
     {
       "Date": "05/15/2025",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,10 +23,12 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
+    assert len(statement.lines) == 3
     assert len(statement.invest_lines) == 24
 
 
 def test_ids(statement):
+    assert statement.lines[0].id == "20250529-1"
     assert statement.invest_lines[0].id == "20230922-1"
     assert statement.invest_lines[1].id == "20230922-2"
 
@@ -238,3 +240,24 @@ def test_nra_tax_adj(statement):
     assert line.amount == Decimal("-0.29")
     assert line.security_id == "AAPL"
     assert line.unit_price is None
+
+
+def test_posted_atm_withdrawal(statement):
+    line = next(x for x in statement.lines if x.id == "20250607-1")
+    assert line.memo == "CHASE MAIN ST ANYTOWN"
+    assert line.trntype == "ATM"
+    assert line.amount == Decimal("-23.50")
+
+
+def test_posted_interest(statement):
+    line = next(x for x in statement.lines if x.id == "20250530-1")
+    assert line.memo == "Interest Paid"
+    assert line.trntype == "INT"
+    assert line.amount == Decimal("0.03")
+
+
+def test_posted_transfer(statement):
+    line = next(x for x in statement.lines if x.id == "20250529-1")
+    assert line.memo == "Funds Transfer from Brokerage"
+    assert line.trntype == "XFER"
+    assert line.amount == Decimal("100")


### PR DESCRIPTION
Add basic support for exported JSON downloads of transactions in Checking accounts.

Test transaction types:

- ATM withdrawal
- Interest
- Transfer from linked Brokerage account