### PR TITLE
Fix Makefile typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 .PHONY: coverage
 coverage:
-	pytest --cov src/ofxstatement
+	pytest --cov src/ofxstatement_schwab_json
 
 .PHONY: black
 black:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 all: test mypy black
 
-PHONY: test
+.PHONY: test
 test:
 	pytest
 
-PHONY: coverage
-coverage: bin/pytest
+.PHONY: coverage
+coverage:
 	pytest --cov src/ofxstatement
 
 .PHONY: black
 black:
-	black setup.py src tests
+	black src tests
 
 .PHONY: mypy
 mypy:

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -232,6 +232,7 @@ def test_adr_mgmt_fee(statement):
     assert line.security_id is None
     assert line.unit_price is None
 
+
 def test_nra_tax_adj(statement):
     line = next(x for x in statement.invest_lines if x.id == "20250515-1")
     assert line.trntype == "INVEXPENSE"


### PR DESCRIPTION
Changes:

- Change `PHONY` to `.PHONY` - see https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
- Fix `coverage` target syntax
  - Remove dependency on `bin/pytest` (`pytest` is provided by `pipenv`)
  - Fix directory path in `pytest --cov` command
- Remove `setup.py` from `black` rule; `setup.py` does not exist
- Apply and commit `black` fixes to `tests/test_statement.py`

## Testing

```bash
python -m virtualenv venv
./venv/bin/pip install pipenv
./venv/bin/pipenv run make all
```

(The `coverage` target is still broken; it requires https://github.com/edwagner/ofxstatement-schwab-json/pull/10 to install `pytest-cov`.)