### PR TITLE
Makefile coverage: generate both text and HTML reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 .PHONY: coverage
 coverage:
-	pytest --cov src/ofxstatement_schwab_json
+	pytest --cov src/ofxstatement_schwab_json --cov-report term --cov-report html
 
 .PHONY: black
 black:


### PR DESCRIPTION
Add `--cov-report html` to generate a browser-viewable HTML report of line-by-line coverage to identify gaps in unit testing.

## Testing

```bash
pipenv run make coverage
...
PASSED                                                                 [100%]

=============================== tests coverage ===============================
______________ coverage: platform linux, python 3.10.12-final-0 ______________

Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
src/ofxstatement_schwab_json/__init__.py       0      0   100%
src/ofxstatement_schwab_json/plugin.py       152      8    95%
--------------------------------------------------------------
TOTAL                                        152      8    95%
Coverage HTML written to dir htmlcov
============================= 26 passed in 0.27s =============================
```

The `htmlcov` directory contains web pages that render line-by-line coverage from unit tests; the red lines indicate code that is not covered by any unit test:

![image](https://github.com/user-attachments/assets/537da614-d3a4-4d9a-b354-6a04176e7261)
