### PR TITLE
PostedTransactions: add support for VISA withdrawals and ATM fee rebates

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -20,6 +20,7 @@ POSTED_TRANSACTION_TYPES = {
     "DEBIT": "DEBIT",
     "INTADJUST": "INT",
     "TRANSFER": "XFER",
+    "VISA": "POS",
 }
 
 

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -17,6 +17,7 @@ import json
 POSTED_TRANSACTION_TYPES = {
     # Map Schwab PostedTransactions types to ofxstatement TRANSACTION_TYPES
     "ATM": "ATM",
+    "ATMREBATE": "CREDIT",
     "DEBIT": "DEBIT",
     "INTADJUST": "INT",
     "TRANSFER": "XFER",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "ABC COMPANY LIMITED",
+      "Date": "06/25/2025",
+      "RunningBalance": "$489.17",
+      "Withdrawal": "$30.79",
+      "Deposit": "",
+      "Type": "VISA"
+    },
+    {
+      "CheckNumber": null,
       "Description": "TRIAL ACCTVERIFY 250615",
       "Date": "06/16/2025",
       "RunningBalance": "$549.87",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "ATM Fee Rebate",
+      "Date": "06/30/2025",
+      "RunningBalance": "$486.89",
+      "Withdrawal": "",
+      "Deposit": "$14.50",
+      "Type": "ATMREBATE"
+    },
+    {
+      "CheckNumber": null,
       "Description": "ABC COMPANY LIMITED",
       "Date": "06/25/2025",
       "RunningBalance": "$489.17",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 6
+    assert len(statement.lines) == 7
     assert len(statement.invest_lines) == 29
 
 
@@ -333,3 +333,10 @@ def test_posted_ach_withdrawal(statement):
     assert line.memo == "TRIAL ACCTVERIFY 250615"
     assert line.trntype == "DEBIT"
     assert line.amount == Decimal("-0.46")
+
+
+def test_posted_visa_debit(statement):
+    line = next(x for x in statement.lines if x.id == "20250625-1")
+    assert line.memo == "ABC COMPANY LIMITED"
+    assert line.trntype == "POS"
+    assert line.amount == Decimal("-30.79")

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 7
+    assert len(statement.lines) == 8
     assert len(statement.invest_lines) == 29
 
 
@@ -340,3 +340,10 @@ def test_posted_visa_debit(statement):
     assert line.memo == "ABC COMPANY LIMITED"
     assert line.trntype == "POS"
     assert line.amount == Decimal("-30.79")
+
+
+def test_posted_atmrebate(statement):
+    line = next(x for x in statement.lines if x.id == "20250630-1")
+    assert line.memo == "ATM Fee Rebate"
+    assert line.trntype == "CREDIT"
+    assert line.amount == Decimal("14.50")


### PR DESCRIPTION
Add support for two more Schwab Checking account `PostedTransactions` transaction types:

- `"ATMREBATE"`: ATM-withdrawal-fee reimbursements.
- `"VISA"`: point-of-sale payment using the associated (Visa) debit card