### PR TITLE
PostedTransactions: support "DEPOSIT" transaction type

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -19,6 +19,7 @@ POSTED_TRANSACTION_TYPES = {
     "ATM": "ATM",
     "ATMREBATE": "CREDIT",
     "DEBIT": "DEBIT",
+    "DEPOSIT": "DEP",
     "INTADJUST": "INT",
     "TRANSFER": "XFER",
     "VISA": "POS",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "Deposit Mobile Banking",
+      "Date": "07/12/2025",
+      "RunningBalance": "$668.19",
+      "Withdrawal": "",
+      "Deposit": "$8.00",
+      "Type": "DEPOSIT"
+    },
+    {
+      "CheckNumber": null,
       "Description": "ATM Fee Rebate",
       "Date": "06/30/2025",
       "RunningBalance": "$486.89",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 8
+    assert len(statement.lines) == 9
     assert len(statement.invest_lines) == 29
 
 
@@ -347,3 +347,10 @@ def test_posted_atmrebate(statement):
     assert line.memo == "ATM Fee Rebate"
     assert line.trntype == "CREDIT"
     assert line.amount == Decimal("14.50")
+
+
+def test_posted_deposit(statement):
+    line = next(x for x in statement.lines if x.id == "20250712-1")
+    assert line.memo == "Deposit Mobile Banking"
+    assert line.trntype == "DEP"
+    assert line.amount == Decimal("8.00")


### PR DESCRIPTION
`DEPOSIT` is used for mobile check deposits; map to the `"DEP"` transaction type.