### PR TITLE
PostedTransactions: support "CHECK" transaction type

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -18,6 +18,7 @@ POSTED_TRANSACTION_TYPES = {
     # Map Schwab PostedTransactions types to ofxstatement TRANSACTION_TYPES
     "ATM": "ATM",
     "ATMREBATE": "CREDIT",
+    "CHECK": "CHECK",
     "DEBIT": "DEBIT",
     "DEPOSIT": "DEP",
     "INTADJUST": "INT",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,15 @@
   "TotalTransactionsAmount": "$526.12",
   "PostedTransactions": [
     {
+      "CheckNumber": "101",
+      "Description": "Check Paid #101",
+      "Date": "10/01/2025",
+      "RunningBalance": "$4,522.22",
+      "Withdrawal": "$870.80",
+      "Deposit": "",
+      "Type": "CHECK"
+    },
+    {
       "CheckNumber": null,
       "Description": "Deposit Mobile Banking",
       "Date": "07/12/2025",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 9
+    assert len(statement.lines) == 10
     assert len(statement.invest_lines) == 30
 
 
@@ -364,3 +364,10 @@ def test_posted_deposit(statement):
     assert line.memo == "Deposit Mobile Banking"
     assert line.trntype == "DEP"
     assert line.amount == Decimal("8.00")
+
+
+def test_posted_check(statement):
+    line = next(x for x in statement.lines if x.id == "20251001-1")
+    assert line.memo == "Check Paid #101"
+    assert line.trntype == "CHECK"
+    assert line.amount == Decimal("-870.80")


### PR DESCRIPTION
The `CHECK` transaction type is a result of issuing a paper check from the checking account.