### PR TITLE
PostedTransactions: support "WIRE" transaction type

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -24,7 +24,6 @@ POSTED_TRANSACTION_TYPES = {
     "INTADJUST": "INT",
     "TRANSFER": "XFER",
     "VISA": "POS",
-    "WIRE": "XFER",
 }
 
 
@@ -269,7 +268,7 @@ class SchwabJsonParser(AbstractStatementParser):
             amount=withdrawal or deposit,
         )
         line.check_no = details.get("CheckNumber")
-        if details["Type"] == "ACH":
+        if details["Type"] in ("ACH", "WIRE"):
             if withdrawal:
                 line.trntype = "DEBIT"
             else:

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -5,6 +5,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "Incoming Wire",
+      "Date": "10/10/2025",
+      "RunningBalance": "$5,727.13",
+      "Withdrawal": "",
+      "Deposit": "$399.00",
+      "Type": "WIRE"
+    },
+    {
+      "CheckNumber": null,
       "Description": "Outgoing Wire",
       "Date": "10/09/2025",
       "RunningBalance": "$5,727.13",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 11
+    assert len(statement.lines) == 12
     assert len(statement.invest_lines) == 36
 
 
@@ -433,8 +433,15 @@ def test_posted_check(statement):
     assert line.amount == Decimal("-870.80")
 
 
-def test_posted_wire(statement):
+def test_posted_outgoing_wire(statement):
     line = next(x for x in statement.lines if x.id == "20251009-1")
     assert line.memo == "Outgoing Wire"
-    assert line.trntype == "XFER"
+    assert line.trntype == "DEBIT"
     assert line.amount == Decimal("-400.00")
+
+
+def test_posted_incoming_wire(statement):
+    line = next(x for x in statement.lines if x.id == "20251010-1")
+    assert line.memo == "Incoming Wire"
+    assert line.trntype == "CREDIT"
+    assert line.amount == Decimal("399.00")


### PR DESCRIPTION
The `"WIRE"` transaction type is a result of issuing an outbound wire from the checking account.

Similarly to the `"ACH"` transaction type, map to the `"CREDIT"` or `"DEBIT"` transaction type based on whether the transaction is a deposit or withdrawal.

Mapping to `"CREDIT"` in this PR is done pre-emptively and speculatively; real-world test data is not available to verify/validate this mapping.