### PR TITLE
BrokerageTransactions: support actions "Short Term Cap Gain Reinvest" and "Long Term Cap Gain Reinvest"

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -95,9 +95,15 @@ class SchwabJsonParser(AbstractStatementParser):
                 or action == "Special Qual Div"
             ):
                 self.add_income_line(id, date, "DIV", tran)
-            elif action == "Long Term Cap Gain":
+            elif (
+                action == "Long Term Cap Gain"
+                or action == "Long Term Cap Gain Reinvest"
+            ):
                 self.add_income_line(id, date, "CGLONG", tran)
-            elif action == "Short Term Cap Gain":
+            elif (
+                action == "Short Term Cap Gain"
+                or action == "Short Term Cap Gain Reinvest"
+            ):
                 self.add_income_line(id, date, "CGSHORT", tran)
             elif action == "Bank Interest" and len(tran["Symbol"]) > 0:
                 self.add_income_line(id, date, "INTEREST", tran)

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -114,6 +114,30 @@
   ],
   "BrokerageTransactions": [
     {
+      "Date": "12/11/2025",
+      "Action": "Short Term Cap Gain Reinvest",
+      "Symbol": "FXAIX",
+      "Description": "FIDELITY 500 INDEX FUND",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$39.45",
+      "ItemIssueId": "278422687",
+      "AcctgRuleCd": "1"
+    },
+    {
+      "Date": "12/10/2025",
+      "Action": "Long Term Cap Gain Reinvest",
+      "Symbol": "FXNAX",
+      "Description": "FIDELITY U.S. BOND INDEX FUND",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$61.44",
+      "ItemIssueId": "276452177",
+      "AcctgRuleCd": "1"
+    },
+    {
       "Date": "06/02/2025",
       "Action": "Journal",
       "Symbol": "SNSXX",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -24,7 +24,7 @@ def statement() -> ofxstatement.statement.Statement:
 def test_parsing(statement):
     assert statement is not None
     assert len(statement.lines) == 12
-    assert len(statement.invest_lines) == 36
+    assert len(statement.invest_lines) == 38
 
 
 def test_ids(statement):
@@ -361,6 +361,22 @@ def test_advisor_fee(statement):
     assert line.amount == Decimal("-419.08")
     assert line.security_id is None
     assert line.unit_price is None
+
+
+def test_short_term_cap_gain_reinvestment(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20251211-1")
+    assert line.trntype == "INCOME"
+    assert line.trntype_detailed == "CGSHORT"
+    assert line.security_id == "FXAIX"
+    assert line.amount == Decimal("39.45")
+
+
+def test_long_term_cap_gain_reinvestment(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20251210-1")
+    assert line.trntype == "INCOME"
+    assert line.trntype_detailed == "CGLONG"
+    assert line.security_id == "FXNAX"
+    assert line.amount == Decimal("61.44")
 
 
 def test_posted_atm_withdrawal(statement):


### PR DESCRIPTION
These are typically downloaded as a pair of transactions:

- A "Short (or Long) Term Cap Gain Reinvest" transaction representing the gains (income)
- A "Reinvest Shares" transaction representing the actual re-investment of those gains