### PR TITLE
Support "Short Term Cap Gain Reinvest" and "Long Term Cap Gain Reinvest"

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -95,9 +95,17 @@ class SchwabJsonParser(AbstractStatementParser):
                 or action == "Special Qual Div"
             ):
                 self.add_income_line(id, date, "DIV", tran)
-            elif action == "Long Term Cap Gain":
+            elif (
+                action == "Long Term Cap Gain"
+                or action
+                == "Long Term Cap Gain Reinvest"  # This usually comes paired with a separate "Reinvest Shares" action
+            ):
                 self.add_income_line(id, date, "CGLONG", tran)
-            elif action == "Short Term Cap Gain":
+            elif (
+                action == "Short Term Cap Gain"
+                or action
+                == "Short Term Cap Gain Reinvest"  # This usually comes paired with a separate "Reinvest Shares" action
+            ):
                 self.add_income_line(id, date, "CGSHORT", tran)
             elif action == "Bank Interest" and len(tran["Symbol"]) > 0:
                 self.add_income_line(id, date, "INTEREST", tran)

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -275,6 +275,18 @@
     },
     {
       "Date": "01/13/2024",
+      "Action": "Short Term Cap Gain Reinvest",
+      "Symbol": "FXAIX",
+      "Description": "FIDELITY 500 INDEX FUND",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$39.45",
+      "ItemIssueId": "278422687",
+      "AcctgRuleCd": "1"
+    },
+    {
+      "Date": "01/13/2024",
       "Action": "Short Term Cap Gain",
       "Symbol": "SWVXX",
       "Description": "SCHWAB VALUE ADVANTAGE MONEY INV",
@@ -282,6 +294,18 @@
       "Quantity": "",
       "Fees & Comm": "",
       "Amount": "$0.01"
+    },
+    {
+      "Date": "01/12/2024",
+      "Action": "Long Term Cap Gain Reinvest",
+      "Symbol": "FXNAX",
+      "Description": "FIDELITY U.S. BOND INDEX FUND",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$61.44",
+      "ItemIssueId": "276452177",
+      "AcctgRuleCd": "1"
     },
     {
       "Date": "01/12/2024",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -24,7 +24,7 @@ def statement() -> ofxstatement.statement.Statement:
 def test_parsing(statement):
     assert statement is not None
     assert len(statement.lines) == 12
-    assert len(statement.invest_lines) == 36
+    assert len(statement.invest_lines) == 38
 
 
 def test_ids(statement):
@@ -293,6 +293,16 @@ def test_special_qualified_dividend(statement):
     assert line.unit_price is None
 
 
+def test_short_term_cap_gain_reinvestment(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20240113-2")
+    assert line.trntype == "INCOME"
+    assert line.trntype_detailed == "CGSHORT"
+    assert line.units is None
+    assert line.amount == Decimal("39.45")
+    assert line.security_id == "FXAIX"
+    assert line.unit_price is None
+
+
 def test_cap_gain_short(statement):
     line = next(x for x in statement.invest_lines if x.id == "20240113-1")
     assert line.trntype == "INCOME"
@@ -300,6 +310,16 @@ def test_cap_gain_short(statement):
     assert line.units is None
     assert line.amount == Decimal("0.01")
     assert line.security_id == "SWVXX"
+    assert line.unit_price is None
+
+
+def test_long_term_cap_gain_reinvestment(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20240112-2")
+    assert line.trntype == "INCOME"
+    assert line.trntype_detailed == "CGLONG"
+    assert line.units is None
+    assert line.amount == Decimal("61.44")
+    assert line.security_id == "FXNAX"
     assert line.unit_price is None
 
 


### PR DESCRIPTION
Also reorganize the tests so that it is easier to see which test corresponds to which statement line.

This feature was originally submitted by rtsai #24, but in order to refactor the tests first I created a separate PR.