### PR TITLE
fix: use valid INVBANKTRAN type CREDIT instead of DEP

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -125,7 +125,7 @@ class SchwabJsonParser(AbstractStatementParser):
                 if action == "Returned Check" or action == "Wire Sent":
                     self.add_bank_line(id, date, "DEBIT", tran)
                 elif action == "Funds Received" or action == "MoneyLink Deposit":
-                    self.add_bank_line(id, date, "DEP", tran)
+                    self.add_bank_line(id, date, "CREDIT", tran)
                 elif (
                     action == "Bank Interest"
                     or action == "Bond Interest"

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -136,7 +136,7 @@ def test_split(statement):
 def test_funds_received(statement):
     line = next(x for x in statement.invest_lines if x.id == "20240404-1")
     assert line.trntype == "INVBANKTRAN"
-    assert line.trntype_detailed == "DEP"
+    assert line.trntype_detailed == "CREDIT"
     assert line.amount == Decimal("5555.00")
     assert line.security_id is None
     assert line.units is None
@@ -146,7 +146,7 @@ def test_funds_received(statement):
 def test_moneylink_deposit(statement):
     line = next(x for x in statement.invest_lines if x.id == "20240403-1")
     assert line.trntype == "INVBANKTRAN"
-    assert line.trntype_detailed == "DEP"
+    assert line.trntype_detailed == "CREDIT"
     assert line.amount == Decimal("1000.00")
     assert line.security_id is None
     assert line.units is None


### PR DESCRIPTION
Summary This PR fixes a build failure caused by using an invalid transaction type (DEP) for Investment Bank Transactions (INVBANKTRAN).

The Issue Recent changes introduced support for "Funds Received" and "MoneyLink Deposit" transaction types, mapping them to "DEP". However, the underlying ofxstatement library enforces a strict schema for INVBANKTRAN types, and "DEP" is not a valid option (valid options are INT, XFER, DEBIT, CREDIT, SRVCHG, OTHER).

This caused make test to fail with: AssertionError: trntype_detailed DEP is not valid for INVBANKTRAN

The Fix

    src/ofxstatement_schwab_json/plugin.py: Changed the mapping for these deposit types from "DEP" to "CREDIT", which is the correct OFX standard for generic investment account deposits.

    tests/test_statement.py: Updated the test assertions to expect "CREDIT" instead of "DEP".

Verification Ran make test.

    Before: Failed (AssertionError on DEP).

    After: 52 passed, 0 failures.