### PR TITLE
Support more transaction types: returned wires, and customer service adjustments

### DIFF
--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -130,7 +130,11 @@ class SchwabJsonParser(AbstractStatementParser):
                     or (action == "Returned Check" and tran["Amount"].startswith("-"))
                 ):
                     self.add_bank_line(id, date, "DEBIT", tran)
-                elif action == "Auto S1 Credit":
+                elif (
+                    action == "Wire Funds Adj"
+                    or action == "Auto S1 Credit"
+                    or action == "Misc Credits"
+                ):
                     self.add_bank_line(id, date, "CREDIT", tran)
                 elif action == "Funds Received" or action == "MoneyLink Deposit":
                     self.add_bank_line(id, date, "DEP", tran)

--- a/src/ofxstatement_schwab_json/plugin.py
+++ b/src/ofxstatement_schwab_json/plugin.py
@@ -15,10 +15,11 @@ LOGGER = logging.getLogger(__name__)
 import json
 
 POSTED_TRANSACTION_TYPES = {
-    # Map Schwab PostedTransactions types to ofxstatement TRANSACTION_TYPES
+    # Map Schwab PostedTransactions types to ofxstatement.statement.STMTTRN_TRNTYPES
     "ATM": "ATM",
     "ATMREBATE": "CREDIT",
     "CHECK": "CHECK",
+    "CREDIT": "CREDIT",
     "DEBIT": "DEBIT",
     "DEPOSIT": "DEP",
     "INTADJUST": "INT",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -4,6 +4,28 @@
   "TotalTransactionsAmount": "$526.12",
   "BrokerageTransactions": [
     {
+      "Date": "06/11/2026",
+      "Action": "Wire Funds Adj",
+      "Symbol": "",
+      "Description": "RETURNED WIRE",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$412.00",
+      "AcctgRuleCd": "1"
+    },
+    {
+      "Date": "06/10/2026 as of 06/09/2026",
+      "Action": "Misc Credits",
+      "Symbol": "",
+      "Description": "CUST SERVICE GEST",
+      "Quantity": "",
+      "Price": "",
+      "Fees & Comm": "",
+      "Amount": "$5.00",
+      "AcctgRuleCd": "1"
+    },
+    {
       "Date": "05/01/2026",
       "Action": "Conversion",
       "Symbol": "CWEN",

--- a/tests/sample-statement.json
+++ b/tests/sample-statement.json
@@ -482,6 +482,15 @@
   "PostedTransactions": [
     {
       "CheckNumber": null,
+      "Description": "Customer Service Gesture",
+      "Date": "06/12/2026",
+      "RunningBalance": "$39.84",
+      "Withdrawal": "",
+      "Deposit": "$4.00",
+      "Type": "CREDIT"
+    },
+    {
+      "CheckNumber": null,
       "Description": "Incoming Wire",
       "Date": "10/10/2025",
       "RunningBalance": "$5,727.13",

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -24,7 +24,7 @@ def statement() -> ofxstatement.statement.Statement:
 def test_parsing(statement):
     assert statement is not None
     assert len(statement.lines) == 12
-    assert len(statement.invest_lines) == 43
+    assert len(statement.invest_lines) == 45
 
 
 def test_ids(statement):
@@ -461,6 +461,22 @@ def test_buy(statement):
     assert line.amount == -100
     assert line.security_id == "SWVXX"
     assert line.unit_price == 1
+
+
+def test_wire_funds_adj(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20260611-1")
+    assert line.memo == "Wire Funds Adj RETURNED WIRE"
+    assert line.trntype == "INVBANKTRAN"
+    assert line.trntype_detailed == "CREDIT"
+    assert line.amount == Decimal("412.00")
+
+
+def test_misc_credits(statement):
+    line = next(x for x in statement.invest_lines if x.id == "20260610-1")
+    assert line.memo == "Misc Credits CUST SERVICE GEST"
+    assert line.trntype == "INVBANKTRAN"
+    assert line.trntype_detailed == "CREDIT"
+    assert line.amount == Decimal("5.00")
 
 
 def test_posted_incoming_wire(statement):

--- a/tests/test_statement.py
+++ b/tests/test_statement.py
@@ -23,7 +23,7 @@ def statement() -> ofxstatement.statement.Statement:
 
 def test_parsing(statement):
     assert statement is not None
-    assert len(statement.lines) == 12
+    assert len(statement.lines) == 13
     assert len(statement.invest_lines) == 45
 
 
@@ -561,3 +561,10 @@ def test_posted_transfer(statement):
     assert line.memo == "Funds Transfer from Brokerage"
     assert line.trntype == "XFER"
     assert line.amount == Decimal("100")
+
+
+def test_posted_credit(statement):
+    line = next(x for x in statement.lines if x.id == "20260612-1")
+    assert line.memo == "Customer Service Gesture"
+    assert line.trntype == "CREDIT"
+    assert line.amount == Decimal("4")


### PR DESCRIPTION
Brokerage Accounts:

- `RETURNED WIRE` - a wire transfer being returned
- `CUST SERVICE GEST` - customer service adjustment

Checking Accounts:

- `CREDIT` - from customer service adjustment